### PR TITLE
Add GSoC section and new packages

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,7 +401,14 @@
 			<li><a href="https://github.com/JuliaAstro"><span class="icon fa-github">&nbsp;&nbsp;JuliaAstro</span></a> on GitHub</li>
 			<li><a href="https://groups.google.com/forum/#!forum/julia-astro"><span class="icon fa-envelope">&nbsp;&nbsp;julia-astro mailing list</span></a> on Google Groups</li>
 			<li><a href="https://discourse.julialang.org/c/domain/astro"><span class="icon fa-comment">&nbsp;&nbsp;Astro/Space topics</span></a>  on JuliaLang Discourse</li>
+			<li><a href="https://riot.im/app/#/room/#JuliaAstro:openastronomy.org"><span class="icon fa-comment">&nbsp;&nbsp;#JuliaAstro:openastronomy.org</span></a> on Matrix</li>
 		    </ul>
+
+		    <header>
+			<h3>Google Summer of Code</h3>
+		    </header>
+
+		    <p>Would you like to contribute to JuliaAstro as part of Google Summer of Code?  You can!  We are member of <a href="https://openastronomy.org/">OpenAstronomy</a>, go to the <a href="https://openastronomy.org/gsoc/">GSoC page</a> to see how to apply and the list of ideas.  You can also propose us your own idea!  If you want to reach us, join <a href="https://riot.im/app/#/room/#JuliaAstro:openastronomy.org">#JuliaAstro:openastronomy.org</a> and <a href="https://riot.im/app/#/room/#openastronomy:matrix.org">#openastronomy:matrix.org</a> on Matrix.</p>
 
 		</div>
 	    </section>
@@ -411,7 +418,7 @@
 	<!-- Footer -->
 	<div id="footer">
 	    <ul class="copyright">
-		<li>&copy; 2015 JuliaAstro contributors</li><li>Design: Prologue by <a href="http://html5up.net">HTML5 UP</a></li>
+		<li>&copy; 2019 JuliaAstro contributors</li><li>Design: Prologue by <a href="http://html5up.net">HTML5 UP</a></li>
 	    </ul>
 	</div>
 

--- a/index.html
+++ b/index.html
@@ -147,6 +147,22 @@
 			</div>
 
 			<div class="4u">
+			  <section class="box">
+			    <h3><a href="https://github.com/JuliaAstro/AstroTime.jl">AstroTime</a></h3>
+			    <p>Astronomical time keeping</p>
+			    <ul>
+			      <li>High-precision, time-scale aware, DateTime-like data type</li>
+			      <li>Supports all commonly used astronomical time scales</li>
+			    </ul>
+			    <p class="links">
+			      <a href="https://juliaastro.github.io/AstroTime.jl/stable/">
+				<span class="icon fa-book">&nbsp;Docs</span>
+			      </a>
+			    </p>
+			  </section>
+			</div>
+
+			<div class="4u">
 			    <section class="box">
 				<h3><a href="https://github.com/JuliaAstro/Cosmology.jl">Cosmology</a></h3>
 				<p>Distances in the Universe</p>
@@ -156,6 +172,10 @@
 				</ul>
 			    </section>
 			</div>
+
+		    </div>
+
+		    <div class="row">
 
 			<div class="4u">
 			    <section class="box">
@@ -167,10 +187,6 @@
 				</ul>
 			    </section>
 			</div>
-
-		    </div>
-
-		    <div class="row">
 
 			<div class="4u">
 			    <section class="box">
@@ -198,6 +214,10 @@
 			    </section>
 			</div>
 
+		    </div>
+
+		    <div class="row">
+
 			<div class="4u">
 			    <section class="box">
 				<h3><a href="https://github.com/JuliaAstro/FITSIO.jl">FITSIO</a></h3>
@@ -214,9 +234,60 @@
 			    </section>
 			</div>
 
+			<div class="4u">
+			    <section class="box">
+				<h3><a href="https://github.com/JuliaAstro/JPLEphemeris.jl">JPLEphemeris</a></h3>
+				<p>JPL ephemerides</p>
+				<!-- <ul> -->
+				<!--   <li></li> -->
+				<!-- </ul> -->
+			    </section>
+			</div>
+
+			<div class="4u">
+			  <section class="box">
+			    <h3><a href="https://github.com/JuliaAstro/LombScargle.jl">LombScargle</a></h3>
+			    <p>Compute Lomb-Scargle periodogram</p>
+			    <ul>
+			      <li>Determine period of unevenly sampled periodic signals</li>
+			      <li>Support multi-threading</li>
+			    </ul>
+			    <p class="links">
+			      <a href="https://juliaastro.github.io/LombScargle.jl/stable/">
+				<span class="icon fa-book">&nbsp;Docs</span>
+			      </a>
+			    </p>
+			  </section>
+			</div>
+
 		    </div>
 
 		    <div class="row">
+
+			<div class="4u">
+			  <section class="box">
+			    <h3><a href="https://github.com/JuliaAstro/SkyCoords.jl">SkyCoords</a></h3>
+			    <p>Astronomical coordinate systems</p>
+			    <ul>
+			      <li>Fast conversion of coordinates between different systems</li>
+			    </ul>
+			  </section>
+			</div>
+
+			<div class="4u">
+			  <section class="box">
+			    <h3><a href="https://github.com/JuliaAstro/UnitfulAstro.jl">UnitfulAstro</a></h3>
+			    <p>Astronomical units</p>
+			    <ul>
+			      <li>Extension of <a href="https://github.com/ajkeller34/Unitful.jl">Unitful.jl</a></li>
+			    </ul>
+			    <p class="links">
+			      <a href="https://juliaastro.github.io/UnitfulAstro.jl/stable/">
+				<span class="icon fa-book">&nbsp;Docs</span>
+			      </a>
+			    </p>
+			  </section>
+			</div>
 
 			<div class="4u">
 			    <section class="box">
@@ -243,20 +314,8 @@
 				CasaCore tables and measurement sets for radio astronomy
 			    </li>
 			    <li>
-				<a href="https://github.com/helgee/JPLEphemeris.jl">JPLEphemeris</a>
-                                JPL ephemerides for Julia
-			    </li>
-			    <li>
-				<a href="https://github.com/giordano/LombScargle.jl">LombScargle</a>
-                                Compute Lomb-Scargle periodogram
-			    </li>
-			    <li>
 				<a href="https://github.com/emmt/OIFITS.jl">OIFITS</a>
 				Support for OI-FITS (optical interferometry data format)
-			    </li>
-			    <li>
-				<a href="https://github.com/kbarbary/SkyCoords.jl">SkyCoords</a>
-				Basic astronomical coordinate systems
 			    </li>
 			</ul>
 		    </div>
@@ -269,16 +328,10 @@
                         <table>
                             <tr>
                                 <th>Package</th>
-                                <th>Julia 0.4</th>
-                                <th>Julia 0.5</th>
-                                <th>Julia 0.6</th>
                                 <th>master (all Julia versions)</th>
                             </tr>
                             <tr>
                                 <td>AstroLib</td>
-                                <td><a href="http://pkg.julialang.org/?pkg=AstroLib"><img src="http://pkg.julialang.org/badges/AstroLib_0.4.svg"></a></td>
-                                <td><a href="http://pkg.julialang.org/?pkg=AstroLib"><img src="http://pkg.julialang.org/badges/AstroLib_0.5.svg"></a></td>
-                                <td><a href="http://pkg.julialang.org/?pkg=AstroLib"><img src="http://pkg.julialang.org/badges/AstroLib_0.6.svg"></a></td>
                                 <td>
                                     <a href="https://travis-ci.org/JuliaAstro/AstroLib.jl">
                                         <img src="https://img.shields.io/travis/JuliaAstro/AstroLib.jl.svg?style=flat-square&label=linux">
@@ -295,10 +348,16 @@
                                 </td>
                             </tr>
                             <tr>
+                                <td>AstroTime</td>
+                                <td><a href="https://travis-ci.org/JuliaAstro/AstroTime.jl">
+                                        <img src="https://img.shields.io/travis/JuliaAstro/AstroTime.jl.svg?style=flat-square&label=linux">
+                                    </a>
+                                    <a href="https://ci.appveyor.com/project/helgee/astronomicaltime-jl/branch/master">
+                                        <img src="https://img.shields.io/appveyor/ci/helgee/astronomicaltime-jl.svg?style=flat-square&label=windows">
+                                    </a></td>
+                            </tr>
+                            <tr>
                                 <td>Cosmology</td>
-                                <td><a href="http://pkg.julialang.org/?pkg=Cosmology"><img src="http://pkg.julialang.org/badges/Cosmology_0.4.svg"></a></td>
-                                <td><a href="http://pkg.julialang.org/?pkg=Cosmology"><img src="http://pkg.julialang.org/badges/Cosmology_0.5.svg"></a></td>
-                                <td><a href="http://pkg.julialang.org/?pkg=Cosmology"><img src="http://pkg.julialang.org/badges/Cosmology_0.6.svg"></a></td>
                                 <td><a href="https://travis-ci.org/JuliaAstro/Cosmology.jl">
                                         <img src="https://img.shields.io/travis/JuliaAstro/Cosmology.jl.svg?style=flat-square&label=linux">
                                     </a>
@@ -308,9 +367,6 @@
                             </tr>
                             <tr>
                                 <td>DustExtinction</td>
-                                <td><a href="http://pkg.julialang.org/?pkg=DustExtinction"><img src="http://pkg.julialang.org/badges/DustExtinction_0.4.svg"></a></td>
-                                <td><a href="http://pkg.julialang.org/?pkg=DustExtinction"><img src="http://pkg.julialang.org/badges/DustExtinction_0.5.svg"></a></td>
-                                <td><a href="http://pkg.julialang.org/?pkg=DustExtinction"><img src="http://pkg.julialang.org/badges/DustExtinction_0.6.svg"></a></td>
                                 <td>
                                     <a href="https://travis-ci.org/JuliaAstro/DustExtinction.jl">
                                         <img src="https://img.shields.io/travis/JuliaAstro/DustExtinction.jl.svg?style=flat-square&label=linux">
@@ -319,9 +375,6 @@
                             </tr>
                             <tr>
                                 <td>ERFA</td>
-                                <td><a href="http://pkg.julialang.org/?pkg=ERFA"><img src="http://pkg.julialang.org/badges/ERFA_0.4.svg"></a></td>
-                                <td><a href="http://pkg.julialang.org/?pkg=ERFA"><img src="http://pkg.julialang.org/badges/ERFA_0.5.svg"></a></td>
-                                <td><a href="http://pkg.julialang.org/?pkg=ERFA"><img src="http://pkg.julialang.org/badges/ERFA_0.6.svg"></a></td>
                                 <td>
                                     <a href="https://travis-ci.org/JuliaAstro/ERFA.jl">
                                         <img src="https://img.shields.io/travis/JuliaAstro/ERFA.jl.svg?style=flat-square&label=linux">
@@ -333,9 +386,6 @@
                             </tr>
                             <tr>
                                 <td>EarthOrientation</td>
-                                <td></td>
-                                <td></td>
-                                <td><a href="http://pkg.julialang.org/?pkg=EarthOrientation"><img src="http://pkg.julialang.org/badges/EarthOrientation_0.6.svg"></a></td>
                                 <td>
                                     <a href="https://travis-ci.org/JuliaAstro/EarthOrientation.jl">
                                         <img src="https://img.shields.io/travis/JuliaAstro/EarthOrientation.jl.svg?style=flat-square&label=linux">
@@ -347,9 +397,6 @@
                             </tr>
                             <tr>
                                 <td>FITSIO</td>
-                                <td><a href="http://pkg.julialang.org/?pkg=FITSIO"><img src="http://pkg.julialang.org/badges/FITSIO_0.4.svg"></a></td>
-                                <td><a href="http://pkg.julialang.org/?pkg=FITSIO"><img src="http://pkg.julialang.org/badges/FITSIO_0.5.svg"></a></td>
-                                <td><a href="http://pkg.julialang.org/?pkg=FITSIO"><img src="http://pkg.julialang.org/badges/FITSIO_0.6.svg"></a></td>
                                 <td>
                                     <a href="https://travis-ci.org/JuliaAstro/FITSIO.jl">
                                         <img src="https://img.shields.io/travis/JuliaAstro/FITSIO.jl.svg?style=flat-square&label=linux">
@@ -366,19 +413,62 @@
                                 </td>
                             </tr>
                             <tr>
+                                <td>JPLEphemeris</td>
+                                <td>
+                                    <a href="https://travis-ci.org/JuliaAstro/JPLEphemeris.jl">
+                                        <img src="https://img.shields.io/travis/JuliaAstro/JPLEphemeris.jl.svg?style=flat-square&label=linux">
+                                    </a>
+                                    <a href="https://ci.appveyor.com/project/JuliaAstrodynamics/jplephemeris-jl/branch/master">
+                                        <img src="https://img.shields.io/appveyor/ci/JuliaAstrodynamics/jplephemeris-jl.svg?style=flat-square&label=windows">
+                                    </a>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>LombScargle</td>
+                                <td>
+                                    <a href="https://travis-ci.org/JuliaAstro/LombScargle.jl">
+                                        <img src="https://img.shields.io/travis/JuliaAstro/LombScargle.jl.svg?style=flat-square&label=linux">
+                                    </a>
+                                    <a href="https://ci.appveyor.com/project/giordano/lombscargle-jl/branch/master">
+                                        <img src="https://img.shields.io/appveyor/ci/giordano/lombscargle-jl.svg?style=flat-square&label=windows">
+                                    </a>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>SkyCoords</td>
+                                <td>
+                                    <a href="https://travis-ci.org/JuliaAstro/SkyCoords.jl">
+                                        <img src="https://img.shields.io/travis/JuliaAstro/SkyCoords.jl.svg?style=flat-square&label=linux">
+                                    </a>
+                                    <a href="https://ci.appveyor.com/project/kbarbary/skycoords-jl/branch/master">
+                                        <img src="https://img.shields.io/appveyor/ci/kbarbary/skycoords-jl.svg?style=flat-square&label=windows">
+                                    </a>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>UnitfulAstro</td>
+                                <td>
+                                    <a href="https://travis-ci.org/JuliaAstro/UnitfulAstro.jl">
+                                        <img src="https://img.shields.io/travis/JuliaAstro/UnitfulAstro.jl.svg?style=flat-square&label=linux">
+                                    </a>
+                                    <a href="https://ci.appveyor.com/project/mweastwood/unitfulastro-jl/branch/master">
+                                        <img src="https://img.shields.io/appveyor/ci/mweastwood/unitfulastro-jl.svg?style=flat-square&label=windows">
+                                    </a>
+                                </td>
+                            </tr>
+                            <tr>
                                 <td>WCS</td>
-                                <td><a href="http://pkg.julialang.org/?pkg=WCS"><img src="http://pkg.julialang.org/badges/WCS_0.4.svg"></a></td>
-                                <td><a href="http://pkg.julialang.org/?pkg=WCS"><img src="http://pkg.julialang.org/badges/WCS_0.5.svg"></a></td>
-                                <td><a href="http://pkg.julialang.org/?pkg=WCS"><img src="http://pkg.julialang.org/badges/WCS_0.6.svg"></a></td>
                                 <td>
                                     <a href="https://travis-ci.org/JuliaAstro/WCS.jl">
                                         <img src="https://img.shields.io/travis/JuliaAstro/WCS.jl.svg?style=flat-square&label=linux">
                                     </a>
+                                    <a href="https://ci.appveyor.com/project/giordano/wcs-jl/branch/master">
+                                        <img src="https://img.shields.io/appveyor/ci/giordano/wcs-jl.svg?style=flat-square&label=windows">
+                                    </a>
                                 </td>
                             </tr>
                         </table>
-                        <p>Julia 0.4, 0.5, and 0.6 show the status of the released package version, as reported by PkgEvaluator. PkgEvaluator is not necessarily up-to-date with the latest release version of each package.<br>
-                        "Master" shows the status of the lastest (unreleased) development version of each package, as reported by Travis and AppVeyor. This includes all supported Julia versions.</p>
+                        <p>"Master" shows the status of the lastest (unreleased) development version of each package, as reported by Travis and AppVeyor. This includes all supported Julia versions.</p>
 
                     </div>
 


### PR DESCRIPTION
* add JuliaAstro room on Matrix (useful for prospective GSoC students)
* add GSoC section
* add new JuliaAstro packages (AstroTime, JPLEphemeris, LombScargle, SkyCoords, UnitfulAstro).  I added only already released packages
* remove all columns from packages status table but the "master" one (PackageEvaluator is not maintained anymore, like all Julia version listed there)