### PR TITLE
DustExtinction.jl updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,9 +182,14 @@
 				<h3><a href="https://github.com/JuliaAstro/DustExtinction.jl">DustExtinction</a></h3>
 				<p>Dust extinction laws & maps</p>
 				<ul>
-				    <li>CCM (1989) and O'Donnell (1994) dust laws</li>
+				    <li>CCM (1989), O'Donnell (1994), and Calzetti (2000) dust laws</li>
 				    <li>SFD (1998) galactic dust map</li>
 				</ul>
+				<p class="links">
+				    <a href="https://juliaastro.github.io/DustExtinction.jl/stable/">
+					<span class="icon fa-book">&nbsp;Docs</span>
+				    </a>
+				</p>
 			    </section>
 			</div>
 
@@ -370,6 +375,9 @@
                                 <td>
                                     <a href="https://travis-ci.org/JuliaAstro/DustExtinction.jl">
                                         <img src="https://img.shields.io/travis/JuliaAstro/DustExtinction.jl.svg?style=flat-square&label=linux">
+									</a>
+									<a href="https://ci.appveyor.com/project/giordano/dustextinction-jl/branch/master">
+                                        <img src="https://img.shields.io/appveyor/ci/giordano/dustextinction-jl.svg?style=flat-square&label=windows">
                                     </a>
                                 </td>
                             </tr>


### PR DESCRIPTION
This pull requests does two things:
1. Adds a link to the DustExtinction.jl documentation
**Note:** This link currently does not work until a new release for DustExtinction is made. I recommended holding off on any merge until this is resolved. 
2. Adds a badge for the windows appveyor status for DustExtinction entry in the status table