### PR TITLE
add docs link to WCS.jl and slack link

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,6 +301,11 @@
 				<ul>
 				    <li>Wrapper for <a href="http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib">wcslib</a> C library</li>
 				</ul>
+				<p class="links">
+			           <a href="https://juliaastro.github.io/WCS.jl/stable/">
+				       <span class="icon fa-book">&nbsp;Docs</span>
+			           </a>
+			       </p>
 			    </section>
 			</div>
 
@@ -500,6 +505,7 @@
 			<li><a href="https://groups.google.com/forum/#!forum/julia-astro"><span class="icon fa-envelope">&nbsp;&nbsp;julia-astro mailing list</span></a> on Google Groups</li>
 			<li><a href="https://discourse.julialang.org/c/domain/astro"><span class="icon fa-comment">&nbsp;&nbsp;Astro/Space topics</span></a>  on JuliaLang Discourse</li>
 			<li><a href="https://riot.im/app/#/room/#JuliaAstro:openastronomy.org"><span class="icon fa-comment">&nbsp;&nbsp;#JuliaAstro:openastronomy.org</span></a> on Matrix</li>
+			<li><a href="slack://channel?id=CMXU6SD7V&team=T68168MUP"><span class="icon fa-comment">&nbsp;&nbsp;#astronomy</span></a> on <a href="https://slackinvite.julialang.org/">JuliaLang Slack</a></li>
 		    </ul>
 
 		    <header>


### PR DESCRIPTION
Add links to WCS.jl documentation as well as a link to the #astronomy channel on the julialang slack under the contributing section