### PR TITLE
Explicit edit link

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -40,6 +40,7 @@ makedocs(
             "assets/favicon.ico",
         ],
         inventory_version = "",
+        edit_link = "source",
     ),
     pages = [
         "Home" => "index.md",


### PR DESCRIPTION
Addresses this warning:

```julia
┌ Warning: Unable to determine HTML(edit_link = ...) from remote HEAD branch, defaulting to "master".
```