### PR TITLE
Top level deploy

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -131,5 +131,6 @@ deploydocs(;
     devbranch = "source",
     devurl = "home",
     cname = "juliaastro.org",
+    versions = nothing,
 )
 @info "Deploy complete"


### PR DESCRIPTION
It seems that this line is actually needed to deploy directly to the root of our site

ref: https://documenter.juliadocs.org/stable/man/hosting/#Deploying-without-the-versioning-scheme

I had [mistakenly thought](https://github.com/JuliaAstro/JuliaAstro.github.io/pull/44/commits/0d3866e94b364995e132076612a1ad5e6ddaf067) that just setting `inventory_version=""` was enough, so just putting this back now