### PR TITLE
re-add packages to the list

### DIFF
--- a/docs/src/ecosystem.md
+++ b/docs/src/ecosystem.md
@@ -119,6 +119,18 @@ The joy of our community is the many astronomy and astrophysics packages availab
 - Read interferometric visibilities (`uvfits`), images (`fits`), and source models
 - Minimal writing support for source models
 
+
+### JuliaAPlavin/VOTables.jl
+
+[![curly braces](assets/code.png) Repository](https://github.com/JuliaAPlavin/VOTables.jl)
+
+[![book icon](assets/book.png) Documentation](https://github.com/JuliaAPlavin/VOTables.jl)
+
+**Read and write VOTable files**
+
+- Text and binary VOTables support
+- Read Unitful numbers and column metadata
+
 ---
 
 ## Images
@@ -232,6 +244,19 @@ The joy of our community is the many astronomy and astrophysics packages availab
 - Morphological operations (rotation, stacking, shifting)
 - Masking routines (circles, annulus, series of annuli)
 - Spectral scaling and descaling
+
+
+### JuliaAPlavin/SkyImages.jl
+
+[![curly braces](assets/code.png) Repository](https://github.com/JuliaAPlavin/SkyImages.jl)
+
+[![book icon](assets/book.png) Documentation](https://aplavin.github.io/SkyImages.jl/test/notebook.html)
+
+**Load astronomical images of the sky and process them with convenient, general, and composable functions.**
+
+- FITS WCS and Healpix images
+- Uniform interface and Makie plotting
+- Work as-is or project onto a rectangular grid
 
 ---
 

--- a/docs/src/ecosystem.md
+++ b/docs/src/ecosystem.md
@@ -256,7 +256,7 @@ The joy of our community is the many astronomy and astrophysics packages availab
 
 - FITS WCS and Healpix images
 - Uniform interface and Makie plotting
-- Work as-is or project onto a rectangular grid
+- Use original data as-is or project onto a rectangular grid
 
 ---
 


### PR DESCRIPTION
Apparently, some packages in the list were lost during the recent reorganization. There were several independent lists before, which probably made it easy to miss some packages during the merge.

I didn't do a comprehensive check before-after, just noticed that two of the packages I added before in https://github.com/JuliaAstro/JuliaAstro.github.io/pull/37 aren't in the current list – while others from that PR are present now. Re-adding them here.