### PR TITLE
Turn off error if no stale previews found in DocPreviewCleanup.yml

### DIFF
--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: julia-actions/cache@v2
 
       - name: Check for stale PR previews
-        shell: julia {0}
+        shell: julia --color=yes {0}
         run: |
           using Pkg
           Pkg.activate(temp = true)

--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -62,8 +62,10 @@ jobs:
 
           if isempty(stale_previews)
               @info "No stale previews"
-              exit(1)
+              println(ENV["GITHUB_ENV"], "FOUND_STALE_PREVIEWS=false")
+              exit()
           end
+          println(ENV["GITHUB_ENV"], "FOUND_STALE_PREVIEWS=true")
 
           for pr in stale_previews
               path = joinpath("previews", "PR$pr")
@@ -71,6 +73,7 @@ jobs:
               run(`git rm -rf $path`)
           end
       - name: Push changes
+        if: ${{ env.FOUND_STALE_PREVIEWS == 'true' }}
         run: |
           git config user.name "Documenter.jl"
           git config user.email "documenter@juliadocs.github.io"


### PR DESCRIPTION
Instead of `error`-ing, set an environment variable that determines if the next step should be run. Lack of stale PR previews is not a failure condition, just an early termination one.