### PR TITLE
Governance document

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -90,7 +90,10 @@ makedocs(
         "Package Ecosystem" => "ecosystem.md",
         case_studies,
         "Comparison with Astropy" => "comparison.md",
-        "Community" => "community.md",
+        "Community" => [
+            "community/juliaastro_community.md",
+            "community/governance.md",
+        ],
     ],
     warnonly = [:missing_docs],
     plugins = [links],

--- a/docs/src/community/governance.md
+++ b/docs/src/community/governance.md
@@ -1,0 +1,59 @@
+# JuliaAstro Governance
+
+The following contains the formal governance structure of the JuliaAstro project. This document clarifies how decisions are made with respect to community interactions, including the relationship between open source development and work that may be funded by for-profit and non-profit entities.
+
+## Code of Conduct
+The JuliaAstro community is committed to maintaining a welcoming, civil and constructive environment. All members are expected to adhere to the [Julia Community Standards](https://julialang.org/community/standards/).
+
+## Current Steering Council
+
+* tbd
+
+## Advisory Committee
+
+* tbd
+
+## Governing Rules and Duties
+
+### Steering Council
+
+The Project has a Steering Council that consists of Project Contributors who have produced contributions that are substantial in quality and quantity, and sustained over at least one year. The role of the Council is to provide active leadership for the Project in making everyday decisions on technical and administrative issues, through working with and taking input from the Community.
+
+During the everyday project activities, Council Members participate in all discussions, code review and other project activities as peers with all other Contributors and the Community. In these everyday activities, Council Members do not have any special power or privilege through their membership on the Council. However, it is expected that because of the quality and quantity of their contributions and their expert knowledge of the Project Software and Services that Council Members will provide useful guidance, both technical and in terms of project direction, to potentially less experienced Contributors.
+
+The Steering Council and its Members play a special role in certain situations. In particular, the Council may:
+
+* Make decisions about the overall scope, vision and direction of the project.
+* Make decisions about strategic collaborations with other organizations or individuals.
+* Make decisions about specific technical issues, features, bugs and pull requests. They are the primary mechanism of guiding the code review process and merging pull requests.
+* Make decisions about the Services that are run by the Project and manage those Services for the benefit of the Project and Community.
+* Make decisions when regular community discussion does not produce consensus on an issue in a reasonable time frame.
+
+Steering Council decisions are taken by simple majority.
+
+### Steering Council membership
+
+To become eligible for being a Steering Council Member, an individual must be a Project Contributor who has produced contributions that are substantial in quality and quantity, and sustained over at least one year. Potential Council Members are nominated by existing Council Members or by the Community and voted upon by the existing Council after asking if the potential Member is interested and willing to serve in that capacity.
+
+When considering potential Members, the Council will look at candidates with a comprehensive view of their contributions. This will include but is not limited to code, code review, infrastructure work, mailing list and chat participation, community help/building, education and outreach, design work, etc. We deliberately do not set arbitrary quantitative metrics to avoid encouraging behavior that plays to the metrics rather than the project's overall well-being. We want to encourage a diverse array of backgrounds, viewpoints and talents in our team, which is why we explicitly do not define code as the sole metric on which Council membership will be evaluated.
+
+If a Council Member becomes inactive in the project for a period of one year, they will be considered for removal from the Council. Before removal, the inactive Member will be approached by another Council member to ask if they plan on returning to active participation. If not they will be removed immediately upon a Council vote. If they plan on returning to active participation soon, they will be given a grace period of one year. If they do not return to active participation within that time period they will be removed by vote of the Council without further grace period. All former Council members can be considered for membership again at any time in the future, like any other Project Contributor. Retired Council members will be listed on the project website, acknowledging the period during which they were active in the Council.
+
+The Council reserves the right to eject current Members if they are deemed to be actively harmful to the Project's well-being, and attempts at communication and conflict resolution have failed.
+
+## Fiscal Decisions
+
+All fiscal decisions are made by the steering council to ensure any funds are spent in a manner that furthers the mission of the Project. Fiscal decisions require majority approval by acting steering council members.
+
+## Advisory Committee
+
+The Project has an Advisory Committee that works to ensure the long-term well-being of the Project. The Committee advises the Steering Council and may be called upon to break deadlocks or serious disagreements in the Council. The Community can ask the Committee to review actions taken by the Council, and the Committee will meet annually to review Project activities. Committee decisions are taken in consensus. Members of the Advisory Committee are appointed by the Steering Council.
+
+## Conflict of Interest
+
+It is expected that Steering Council and Advisory Committee Members will be employed at a wide range of companies, universities and non-profit organizations. Because of this, it is possible that Members will have conflicts of interest. Such conflicts of interest include, but are not limited to:
+
+* Financial interests, such as investments, employment or contracting work, outside of the Project that may influence their work on the Project.
+* Access to proprietary information of their employer that could potentially leak into their work with the Project.
+
+All members of the Council and Committee shall disclose any conflict of interest they may have. Members with a conflict of interest in a particular issue may participate in Council discussions on that issue, but must recuse themselves from voting on the issue.

--- a/docs/src/community/governance.md
+++ b/docs/src/community/governance.md
@@ -1,5 +1,8 @@
 # JuliaAstro Governance
 
+!!! note
+    This document is still a work in progress.
+
 The following contains the formal governance structure of the JuliaAstro project. This document clarifies how decisions are made with respect to community interactions, including the relationship between open source development and work that may be funded by for-profit and non-profit entities.
 
 ## Code of Conduct

--- a/docs/src/community/juliaastro_community.md
+++ b/docs/src/community/juliaastro_community.md
@@ -1,4 +1,4 @@
-# Community
+# JuliaAstro Community
 
 ## Platforms
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,13 +8,13 @@
 * Want to see a curated list of different packages available? Check out our [Package Ecosystem](@ref eco) page.
 * Want to see real world applications of JuliaAstro? Check out our [Case Studies](@ref) page.
 * Coming from astropy? Check out our [Comparison with Astropy](@ref) page.
-* Want to learn more about getting involved? Check out our [Community](@ref) page.
+* Want to learn more about getting involved? Check out our [Community](@ref "JuliaAstro Community") page.
 
 Further documentation for curated packages in the JuliaAstro and larger Julia ecosystem can be viewed directly via the navbar above. Pure Julia packages are marked with a closed circle ⬤, while wrapper packages for other languages are marked with an open circle ◯.
 
 ## Talks and Presentations
 
-Below is a growing list of JuliaAstro and other related aero/astro presentations in Julia. If you have a presentation that you think would be a good addition, [please get in touch](@ref Community)!
+Below is a growing list of JuliaAstro and other related aero/astro presentations in Julia. If you have a presentation that you think would be a good addition, [please get in touch](@ref "JuliaAstro Community")!
 
 !!! details "JuliaCon 2021"
     - A Short History of AstroTime.jl [[pretalx]](https://pretalx.com/juliacon2021/talk/TJ3FNS/) [[video]](https://www.youtube.com/watch?v=HGlsRoy1JxU)


### PR DESCRIPTION
Starting the page for our [JuliaAstro governance document](https://juliaastro.org/previews/PR142/home/community/governance/).

Based on [SciML's governance document](https://sciml.ai/governance/).